### PR TITLE
Possibility to submit a new job when running an update but no job was…

### DIFF
--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -150,6 +150,8 @@ func UpdateAction(c *cli.Context) error {
 
 	update.AllowNonRestoredState = c.Bool("allow-non-restored-state")
 
+	update.IsNewJobSubmissionFlagSet = c.Bool("install")
+
 	err := operator.Update(update)
 
 	if err != nil {
@@ -290,6 +292,10 @@ func main() {
 				cli.BoolFlag{
 					Name:  "allow-non-restored-state, anrs",
 					Usage: "Allow the job to run if the state cannot be restored",
+				},
+				cli.BoolFlag{
+					Name:  "install, i",
+					Usage: "Deploys a new job if there is no job running",
 				},
 			},
 			Action: UpdateAction,

--- a/cmd/cli/operations/update_job.go
+++ b/cmd/cli/operations/update_job.go
@@ -14,15 +14,16 @@ import (
 // UpdateJob represents the configuration used for
 // updating a job on the Flink cluster
 type UpdateJob struct {
-	JobNameBase           string
-	LocalFilename         string
-	RemoteFilename        string
-	APIToken              string
-	EntryClass            string
-	Parallelism           int
-	ProgramArgs           string
-	SavepointDir          string
-	AllowNonRestoredState bool
+	JobNameBase               string
+	LocalFilename             string
+	RemoteFilename            string
+	APIToken                  string
+	EntryClass                string
+	Parallelism               int
+	ProgramArgs               string
+	SavepointDir              string
+	AllowNonRestoredState     bool
+	IsNewJobSubmissionFlagSet bool
 }
 
 func (o RealOperator) filterJobsByRunningAndNameBase(jobs []flink.Job, jobNameBase string) (ret []flink.Job) {
@@ -97,7 +98,15 @@ func (o RealOperator) Update(u UpdateJob) error {
 	}
 	switch len(runningJobs) {
 	case 0:
-		return fmt.Errorf("no instance running for job name base \"%v\". Aborting update", u.JobNameBase)
+		if u.IsNewJobSubmissionFlagSet {
+			err = o.Deploy(deploy)
+			if err != nil {
+				return err
+			}
+			return nil
+		} else {
+			return fmt.Errorf("no instance running for job name base \"%v\". Aborting update", u.JobNameBase)
+		}
 	case 1:
 		log.Printf("found exactly 1 running job with base name: \"%v\"", u.JobNameBase)
 		job := runningJobs[0]


### PR DESCRIPTION
Hi Nick,

thank you for your great improvements to the flink-deployer. Thank's also to the ing-guys.
In my opinion it makes sense to use the Flink API to retrieve the latest checkpoint. That reduces complexity and makes the deployer more flexible.

As we would like to use the flink-deployer for our cd-pipeline we don't want to be able to only update jobs but also submitting new jobs if a job doesn't exist. Therefore we decided to introduce a flag to the update command (--install) which deploys a new job if no job is running with the corresponding JobNameBase. This is just a proposal. Comments are welcome.

Thank you